### PR TITLE
X11 Users fix

### DIFF
--- a/.tools/pre_launch_test.sh
+++ b/.tools/pre_launch_test.sh
@@ -5,6 +5,8 @@ if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
   # Verify if the script is run as root, which is required for Docker to function correctly
   if [ "$EUID" -ne 0 ]; then
     echo "Please run this script as root (by using sudo). Otherwise docker won't work properly."
+    echo "Make sure to use the -E flag to preserve the environment variables when using ssh and X11"
+    echo "E.g. sudo -E bash launch.sh"
     exit 1
   fi
 fi

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ DL4MicEverywhere aims to make deep learning more accessible, transparent, and pa
 
 1. Clone this repo: `git clone https://github.com/HenriquesLab/DL4MicEverywhere.git`
 2. Navigate to the repo directory 
-3. Run `sudo bash launch.sh` to launch the notebook selection GUI
+3. Run `sudo -E bash launch.sh` to launch the notebook selection GUI
 4. Choose a notebook and run!
 
 Docker wraps up all dependencies in a tidy bundle. Simply launch and access deep learning workflows through an intuitive interface!

--- a/docs/CLI_USER_GUIDE.md
+++ b/docs/CLI_USER_GUIDE.md
@@ -26,13 +26,13 @@ In case you just want to execute using the terminal this are the arguments that 
 This would be a simple usage case, where one of the provided `configuration.yaml` files is used:
 
 ```
-sudo bash launch.sh -c ./notebooks/CARE_2D_DL4Mic/configuration.yaml -d ./data_folder -o ./results_folder
+sudo -E bash launch.sh -c ./notebooks/CARE_2D_DL4Mic/configuration.yaml -d ./data_folder -o ./results_folder
 ```
 
 A more complex example would be:
 
 ```
-sudo bash launch.sh -c ./my_notebooks/CARE_2D_DL4Mic/configuration.yaml -d /home/user/Documents/data_folder -o /home/user/Documents/results_folder -g -n /home/user/Desktop/MyFancyZeroCostDL4MicNotebook.ipynb -r ./modified_requirements.txt -t MyNewContainer
+sudo -E bash launch.sh -c ./my_notebooks/CARE_2D_DL4Mic/configuration.yaml -d /home/user/Documents/data_folder -o /home/user/Documents/results_folder -g -n /home/user/Desktop/MyFancyZeroCostDL4MicNotebook.ipynb -r ./modified_requirements.txt -t MyNewContainer
 ```
 
 where you use your own `configuration.yaml` file, your ZeroCost4Mic style notebook and your `requirements.txt`file; also allowing the container to use GPUs and giving the tag `MyNewContainer`to the docker image that will be created.

--- a/docs/GUI_USER_GUIDE.md
+++ b/docs/GUI_USER_GUIDE.md
@@ -4,7 +4,7 @@
 Once the requirements have been installed, to launch the GUI, you should execute the following command on the terminal:
 
 ```
-sudo bash launch.sh
+sudo -E bash launch.sh
 ```
 
 After running the previous command, the following window will pop up:


### PR DESCRIPTION
Hi all,

I noticed the instructions as shown don't work for users remoting over ssh using x11, (HPC users who maybe want to use the GUI). It's an easy fix, they just need to use sudo -E instead of sudo to preserve all the x11 env variables.

(Will push constructor stuff soon too)

Thanks

Craig